### PR TITLE
fix(deps): patch image parser denial of service

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format:fix": "turbo run format:fix",
     "typecheck": "turbo run typecheck",
     "start": "turbo run start",
-    "test": "turbo run test",
+    "test": "pnpm run security:check && turbo run test",
     "changelog:check": "turbo run changelog:check --filter=magic-modal",
     "release:check": "turbo run release:check --filter=magic-modal",
     "build": "turbo run build",
@@ -38,6 +38,7 @@
     "registry:build": "shadcn build --output apps/docs/public/r && pnpm --filter @magic-modal/docs exec oxfmt public/r",
     "registry:check": "shadcn registry validate && pnpm registry:typecheck && pnpm registry:build",
     "registry:typecheck": "pnpm --filter magic-modal exec tsc --project ../../registry/tsconfig.json",
+    "security:check": "node tools/security-check.mjs && pnpm audit",
     "doctor": "turbo run doctor"
   },
   "config": {

--- a/patches/image-size@1.2.1.patch
+++ b/patches/image-size@1.2.1.patch
@@ -1,0 +1,61 @@
+diff --git a/dist/types/icns.js b/dist/types/icns.js
+index f2bfafef3723cb423b110304815e56e3f97f81e0..0739704629092270dd734face166b5db91047d52 100644
+--- a/dist/types/icns.js
++++ b/dist/types/icns.js
+@@ -74,6 +74,13 @@ function getImageSize(type) {
+     const size = ICON_TYPE_SIZE[type];
+     return { width: size, height: size, type };
+ }
++function assertValidEntry(inputLength, fileLength, imageOffset, imageLength) {
++    if (imageLength < SIZE_HEADER ||
++        imageOffset + imageLength > fileLength ||
++        imageOffset + imageLength > inputLength) {
++        throw new TypeError('Invalid ICNS entry length');
++    }
++}
+ exports.ICNS = {
+     validate: (input) => (0, utils_1.toUTF8String)(input, 0, 4) === 'icns',
+     calculate(input) {
+@@ -81,6 +88,7 @@ exports.ICNS = {
+         const fileLength = (0, utils_1.readUInt32BE)(input, FILE_LENGTH_OFFSET);
+         let imageOffset = SIZE_HEADER;
+         let imageHeader = readImageHeader(input, imageOffset);
++        assertValidEntry(inputLength, fileLength, imageOffset, imageHeader[1]);
+         let imageSize = getImageSize(imageHeader[0]);
+         imageOffset += imageHeader[1];
+         if (imageOffset === fileLength)
+@@ -92,6 +100,7 @@ exports.ICNS = {
+         };
+         while (imageOffset < fileLength && imageOffset < inputLength) {
+             imageHeader = readImageHeader(input, imageOffset);
++            assertValidEntry(inputLength, fileLength, imageOffset, imageHeader[1]);
+             imageSize = getImageSize(imageHeader[0]);
+             imageOffset += imageHeader[1];
+             result.images.push(imageSize);
+diff --git a/dist/types/utils.js b/dist/types/utils.js
+index 5224bbafe87551ac415cb3de234820ccc0ff6e2c..a8809bf46ab034bd3f64962b921e2c18a26cb35b 100644
+--- a/dist/types/utils.js
++++ b/dist/types/utils.js
+@@ -51,8 +51,9 @@ exports.readUInt = readUInt;
+ function readBox(input, offset) {
+     if (input.length - offset < 4)
+         return;
+-    const boxSize = (0, exports.readUInt32BE)(input, offset);
+-    if (input.length - offset < boxSize)
++    const declaredSize = (0, exports.readUInt32BE)(input, offset);
++    const boxSize = declaredSize === 0 ? input.length - offset : declaredSize;
++    if (boxSize < 8 || input.length - offset < boxSize)
+         return;
+     return {
+         name: (0, exports.toUTF8String)(input, 4 + offset, 8 + offset),
+@@ -67,9 +68,7 @@ function findBox(input, boxName, offset) {
+             break;
+         if (box.name === boxName)
+             return box;
+-        // Fix the infinite loop by ensuring offset always increases
+-        // If box.size is 0, advance by at least 8 bytes (the size of the box header)
+-        offset += box.size > 0 ? box.size : 8;
++        offset += box.size;
+     }
+ }
+ exports.findBox = findBox;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,15 @@ overrides:
   brace-expansion: ^5.0.9
   fast-uri: ^3.1.5
   hono: ^4.12.34
+  js-yaml@3.15.0: 3.15.1
+  js-yaml@4.3.0: 4.3.1
+  nanoid@3.3.16: 3.3.17
   uuid: ^14.0.0
   postcss: ^8.5.23
   sharp: ^0.35.3
 
 patchedDependencies:
+  image-size@1.2.1: 21f4e087748a17f6200705cd102689cfedf349f63f7529cc8f96ac48a1d8ec6f
   minimatch@3.1.5: 32d5f5d88e8b4b38cb3596270bd0d71e7267ba932937b74599f7100823741f89
 
 importers:
@@ -6579,12 +6583,12 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsc-safe-url@0.2.4:
@@ -7300,8 +7304,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10259,7 +10263,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5(patch_hash=32d5f5d88e8b4b38cb3596270bd0d71e7267ba932937b74599f7100823741f89)
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -10637,7 +10641,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@fastify/deepmerge@2.0.2': {}
 
@@ -10956,7 +10960,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -12116,7 +12120,7 @@ snapshots:
       '@react-navigation/routers': 7.5.5
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       query-string: 7.1.3
       react: 19.2.0
       react-is: 19.2.8
@@ -12152,14 +12156,14 @@ snapshots:
       '@react-navigation/core': 7.17.4(react@19.2.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       react: 19.2.0
       react-native: 0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.0)(supports-color@8.1.1)
       use-latest-callback: 0.2.6(react@19.2.0)
 
   '@react-navigation/routers@7.5.5':
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
 
   '@release-it/conventional-changelog@12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.1)(release-it@21.0.1(@types/node@26.1.2)(supports-color@8.1.1))':
     dependencies:
@@ -14014,7 +14018,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -14024,7 +14028,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -14665,7 +14669,7 @@ snapshots:
       expo-symbols: 55.0.9(expo-font@55.0.8)(expo@55.0.28)(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       query-string: 7.1.3
       react: 19.2.0
       react-fast-compare: 3.2.2
@@ -15462,7 +15466,7 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  image-size@1.2.1:
+  image-size@1.2.1(patch_hash=21f4e087748a17f6200705cd102689cfedf349f63f7529cc8f96ac48a1d8ec6f):
     dependencies:
       queue: 6.0.2
 
@@ -16082,12 +16086,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -16734,7 +16738,7 @@ snapshots:
       flow-enums-runtime: 0.0.6
       graceful-fs: 4.2.11
       hermes-parser: 0.35.0
-      image-size: 1.2.1
+      image-size: 1.2.1(patch_hash=21f4e087748a17f6200705cd102689cfedf349f63f7529cc8f96ac48a1d8ec6f)
       invariant: 2.2.4
       jest-worker: 29.7.0
       jsc-safe-url: 0.2.4
@@ -17104,7 +17108,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -17607,7 +17611,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,9 @@ overrides:
   "brace-expansion": "^5.0.9"
   "fast-uri": "^3.1.5"
   "hono": "^4.12.34"
+  "js-yaml@3.15.0": "3.15.1"
+  "js-yaml@4.3.0": "4.3.1"
+  "nanoid@3.3.16": "3.3.17"
   "uuid": "^14.0.0"
   # Both of these reach us through next in apps/docs, and bumping next fixes
   # neither. It pins `"postcss": "8.4.31"` exactly and takes `sharp: "^0.34.5"`
@@ -33,6 +36,7 @@ overrides:
   "sharp": "^0.35.3"
 
 patchedDependencies:
+  image-size@1.2.1: patches/image-size@1.2.1.patch
   "minimatch@3.1.5": "patches/minimatch@3.1.5.patch"
 
 # pnpm 11 renamed `onlyBuiltDependencies` to `allowBuilds`, which is a map so a
@@ -241,6 +245,16 @@ minimumReleaseAgeExclude:
   - "brace-expansion@5.0.9" # GHSA-rgw5-rvv9-x895
   - "fast-uri@3.1.5" # GHSA-7p8r-x3mc-p8w7
   - "hono@4.12.34" # GHSA-8j4g-w8fx-2239
+  - "js-yaml@3.15.1" # GHSA-5p4m-2wfm-xmqj
+  - "js-yaml@4.3.1" # GHSA-5p4m-2wfm-xmqj
+  - "nanoid@3.3.17" # GHSA-2v37-7h3g-55p8
   # Our own plugin, published from this account 2026-07-27 — same first-party
   # exemption the sibling repos carry. Version-pinned like the rest.
   - "eslint-plugin-safe-jsx@1.3.0"
+
+auditConfig:
+  # image-size has no published fix. The patch above covers both parser
+  # advisories, and tools/security-check.mjs exercises each malformed format.
+  ignoreGhsas:
+    - GHSA-w3rx-r6r6-pgpr
+    - GHSA-5p2g-fcmc-qvqq

--- a/tools/security-check.mjs
+++ b/tools/security-check.mjs
@@ -1,0 +1,68 @@
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const packageRoot = dirname(dirname(require.resolve("image-size")));
+
+const checks = [
+  {
+    name: "ICNS zero-length entry",
+    source: `
+      const { ICNS } = require(${JSON.stringify(join(packageRoot, "dist/types/icns.js"))});
+      const input = Buffer.alloc(16);
+      input.write("icns", 0);
+      input.writeUInt32BE(16, 4);
+      input.write("ic07", 8);
+      input.writeUInt32BE(0, 12);
+      try {
+        ICNS.calculate(input);
+        throw new Error("malformed ICNS entry was accepted");
+      } catch (error) {
+        if (error.message !== "Invalid ICNS entry length") throw error;
+      }
+    `,
+  },
+  {
+    name: "JXL zero-size box",
+    source: `
+      const { JXL } = require(${JSON.stringify(join(packageRoot, "dist/types/jxl.js"))});
+      const input = Buffer.alloc(12);
+      input.write("jxlp", 4);
+      try {
+        JXL.calculate(input);
+      } catch (error) {
+        if (error.message !== "Reached end of input") throw error;
+      }
+    `,
+  },
+  {
+    name: "HEIF zero-size box",
+    source: `
+      const { HEIF } = require(${JSON.stringify(join(packageRoot, "dist/types/heif.js"))});
+      const input = Buffer.alloc(8);
+      input.write("junk", 4);
+      try {
+        HEIF.calculate(input);
+      } catch (error) {
+        if (error.message !== "Invalid HEIF, no size found") throw error;
+      }
+    `,
+  },
+];
+
+for (const check of checks) {
+  const result = spawnSync(process.execPath, ["--eval", check.source], {
+    encoding: "utf8",
+    timeout: 2_000,
+  });
+
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(`${check.name} still blocks the event loop`);
+  }
+  if (result.status !== 0) {
+    throw new Error(`${check.name} failed:\n${result.stderr}`);
+  }
+
+  console.log(`PASS ${check.name}`);
+}


### PR DESCRIPTION
## Summary

Clean installs now stop malformed images from hanging Metro and use fixed releases of `js-yaml` and `nanoid`.

## Details

- Rejects zero-length ICNS entries and makes zero-sized JXL/HEIF boxes consume the remaining buffer, so malformed images can't block Metro's Node.js event loop.
- Resolves `js-yaml` 3.x and 4.x to 3.15.1 and 4.3.1, and `nanoid` 3.x to 3.3.17.
- Runs the malformed-image regressions and `pnpm audit` before the normal test suite. The two ignored `image-size` advisories are covered by the checked-in patch because upstream archived the repo without publishing 2.0.3.

## Testing steps

1. Select Node 24.18, confirm it is active, and install the locked workspace:

   ```sh
   nvm use 24.18
   node --version
   pnpm install --frozen-lockfile
   ```

2. Run the full test command:

   ```sh
   pnpm run test
   ```

   Confirm the ICNS, JXL, and HEIF checks print `PASS`, followed by the package test suites.
