### PR TITLE
fix(deps): patch nanoid zero-size generator denial of service

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   hono: ^4.12.34
   js-yaml@3.15.0: 5.2.2
   js-yaml@4.3.0: 4.3.1
-  nanoid@3.3.16: 3.3.17
+  nanoid@3.3.16: 3.3.18
   uuid: ^14.0.0
   postcss: ^8.5.23
   sharp: ^0.35.3
@@ -7301,8 +7301,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12114,7 +12114,7 @@ snapshots:
       '@react-navigation/routers': 7.5.5
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.0
       react-is: 19.2.8
@@ -12150,14 +12150,14 @@ snapshots:
       '@react-navigation/core': 7.17.4(react@19.2.0)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       react: 19.2.0
       react-native: 0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.0)(supports-color@8.1.1)
       use-latest-callback: 0.2.6(react@19.2.0)
 
   '@react-navigation/routers@7.5.5':
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
 
   '@release-it/conventional-changelog@12.0.0(conventional-commits-filter@6.0.1)(conventional-commits-parser@7.1.1)(release-it@21.0.1(@types/node@26.1.2)(supports-color@8.1.1))':
     dependencies:
@@ -14659,7 +14659,7 @@ snapshots:
       expo-symbols: 55.0.9(expo-font@55.0.8)(expo@55.0.28)(react-native@0.83.10(@babel/core@7.29.7(supports-color@8.1.1))(@react-native/metro-config@0.85.3(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1))(@types/react@19.2.18)(react@19.2.0)(supports-color@8.1.1))(react@19.2.0)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       query-string: 7.1.3
       react: 19.2.0
       react-fast-compare: 3.2.2
@@ -17097,7 +17097,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -17600,7 +17600,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ overrides:
   "hono": "^4.12.34"
   "js-yaml@3.15.0": "5.2.2"
   "js-yaml@4.3.0": "4.3.1"
-  "nanoid@3.3.16": "3.3.17"
+  "nanoid@3.3.16": "3.3.18"
   "uuid": "^14.0.0"
   # Both of these reach us through next in apps/docs, and bumping next fixes
   # neither. It pins `"postcss": "8.4.31"` exactly and takes `sharp: "^0.34.5"`
@@ -247,7 +247,7 @@ minimumReleaseAgeExclude:
   - "hono@4.12.34" # GHSA-8j4g-w8fx-2239
   - "js-yaml@3.15.1" # GHSA-5p4m-2wfm-xmqj
   - "js-yaml@4.3.1" # GHSA-5p4m-2wfm-xmqj
-  - "nanoid@3.3.17" # GHSA-2v37-7h3g-55p8
+  - "nanoid@3.3.18" # GHSA-2v37-7h3g-55p8
   # Our own plugin, published from this account 2026-07-27 — same first-party
   # exemption the sibling repos carry. Version-pinned like the rest.
   - "eslint-plugin-safe-jsx@1.3.0"


### PR DESCRIPTION
## Summary

The workspace now resolves nanoid 3.x to 3.3.18, clearing GHSA-2v37-7h3g-55p8 from every transitive path.

## Details

- Moves the existing `nanoid@3.3.16` override from 3.3.17 to 3.3.18.
- Adds the security release to the 14-day quarantine exception so clean installs can take the fix immediately.
- Refreshes every locked nanoid 3.x consumer without changing any direct package range.

## Testing steps

1. Use Node 24.18 and pnpm 11.19 to install and test the locked workspace:

   ```sh
   pnpm install --frozen-lockfile
   pnpm run test
   ```

   Confirm both commands exit successfully, with no unignored advisories and no failed tests.

2. Run the production browser smoke test:

   ```sh
   pnpm --filter @magic-modal/next-web run smoke:browser
   ```

   Confirm the command exits successfully after exercising the modal flows.
