### PR TITLE
fix(deps): patch xmldom parser vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,8 @@ overrides:
   metro-resolver: ^0.83.8
   metro-config: ^0.83.8
   '@expo/metro-runtime': 55.0.12
+  '@xmldom/xmldom@0.8.13': 0.8.15
+  '@xmldom/xmldom@0.9.10': 0.9.12
   undici: ^8.0.0
   lodash: ^4.18.0
   tmp: ^0.2.6
@@ -4248,15 +4250,13 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version has critical issues, please update to the latest version
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -10983,7 +10983,7 @@ snapshots:
 
   '@expo/plist@0.5.4':
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -13622,9 +13622,9 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -18154,7 +18154,7 @@ snapshots:
 
   plist@3.1.1:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,8 @@ overrides:
   "metro-resolver": "^0.83.8"
   "metro-config": "^0.83.8"
   "@expo/metro-runtime": "55.0.12"
+  "@xmldom/xmldom@0.8.13": "0.8.15"
+  "@xmldom/xmldom@0.9.10": "0.9.12"
   "undici": "^8.0.0"
   "lodash": "^4.18.0"
   "tmp": "^0.2.6"
@@ -52,6 +54,10 @@ minimumReleaseAge: 20160
 
 minimumReleaseAgeExclude:
   - "magic-*"
+  # Security fixes published inside the quarantine window. Remove them after
+  # 2026-09-04.
+  - "@xmldom/xmldom@0.8.15"
+  - "@xmldom/xmldom@0.9.12"
   # Expo SDK 55's live compatibility map moved on 2026-08-17. Its dependency
   # closure contains these fresh releases. Remove them after 2026-08-31.
   - "@expo/router-server@55.0.19"


### PR DESCRIPTION
## Summary

The Expo and Xcode plist dependency paths now use the current security releases of `@xmldom/xmldom`.

## Details

- Moves the Expo plist path from 0.8.13 to 0.8.15.
- Moves the Xcode plist path from 0.9.10 to 0.9.12.
- Lets those security releases bypass the 14-day dependency quarantine until September 4.

## Testing steps

1. From the repository root, run:

   ```sh
   pnpm install --frozen-lockfile
   pnpm test
   ```

   Confirm both commands finish successfully.

2. Run:

   ```sh
   pnpm why @xmldom/xmldom
   ```

   Confirm the dependency tree contains 0.8.15 and 0.9.12.
