### PR TITLE
fix(modal): stop exiting web modals from catching clicks

### DIFF
--- a/examples/next-web/tools/browser-smoke.mjs
+++ b/examples/next-web/tools/browser-smoke.mjs
@@ -176,6 +176,25 @@ try {
     return result.result.value;
   };
 
+  const dispatchClick = async ({ x, y }) => {
+    await devTools.send("Input.dispatchMouseEvent", {
+      button: "left",
+      buttons: 1,
+      clickCount: 1,
+      type: "mousePressed",
+      x,
+      y,
+    });
+    await devTools.send("Input.dispatchMouseEvent", {
+      button: "left",
+      buttons: 0,
+      clickCount: 1,
+      type: "mouseReleased",
+      x,
+      y,
+    });
+  };
+
   await waitFor(
     () =>
       evaluate(`(() => {
@@ -454,8 +473,70 @@ try {
     "the dismissed entry to finish leaving",
   );
 
+  // An exiting entry stays mounted for its animation, but it is no longer the
+  // live modal. Its descendants must leave Chrome's hit-testing immediately.
+  await evaluate(
+    `document.querySelector('[data-testid="open-modal"]').click(); true`,
+  );
+  await waitFor(
+    () =>
+      evaluate(
+        `Boolean(document.querySelector('[data-testid="confirm-modal"]'))`,
+      ),
+    "the pointer-isolation modal",
+  );
+
+  const confirmPoint = await evaluate(`(() => {
+    const confirm = document.querySelector('[data-testid="confirm-modal"]');
+    const { height, left, top, width } = confirm.getBoundingClientRect();
+    window.__magicModalConfirmClicks = 0;
+    confirm.addEventListener("click", () => {
+      window.__magicModalConfirmClicks += 1;
+    });
+    return { x: Math.round(left + width / 2), y: Math.round(top + height / 2) };
+  })()`);
+
+  await dispatchClick(confirmPoint);
+  await waitFor(
+    () =>
+      evaluate(`(() => {
+        const entry = document.querySelector(
+          '[data-testid="magic-modal-stack-entry"]',
+        );
+        return (
+          window.__magicModalConfirmClicks === 1 &&
+          entry?.classList.contains("magic-modal-none")
+        );
+      })()`),
+    "the confirmed entry to start leaving",
+  );
+
+  const staleButtonOwnsPoint = await evaluate(`(() => {
+    const target = document.elementFromPoint(${confirmPoint.x}, ${confirmPoint.y});
+    return Boolean(target?.closest('[data-testid="confirm-modal"]'));
+  })()`);
+  if (staleButtonOwnsPoint) {
+    throw new Error("The exiting modal still owns pointer hit-testing.");
+  }
+
+  await dispatchClick(confirmPoint);
+  const confirmClicks = await evaluate(
+    `new Promise((resolve) => setTimeout(() => resolve(window.__magicModalConfirmClicks), 25))`,
+  );
+  if (confirmClicks !== 1) {
+    throw new Error(`The exiting action fired ${confirmClicks} times.`);
+  }
+
+  await waitFor(
+    () =>
+      evaluate(
+        `document.querySelector('[data-testid="modal-result"]').textContent === "CONFIRMED" && document.querySelectorAll('[data-testid="magic-modal-stack-entry"]').length === 0`,
+      ),
+    "the pointer-isolation exit to settle",
+  );
+
   console.log(
-    "✓ Next.js browser smoke: dialog semantics, stack isolation, focus, Escape, backdrop, and swipe dismissal",
+    "✓ Next.js browser smoke: dialog semantics, stack isolation, focus, Escape, backdrop, swipe dismissal, and exiting pointer isolation",
   );
 } finally {
   devTools?.close();

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -59,7 +59,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "bunchee && node tools/wrap-entrypoints.mjs && node tools/check-web-build.mjs",
+    "build": "bunchee && node tools/wrap-entrypoints.mjs && node tools/check-web-build.mjs && node tools/check-pack-consumer.mjs",
     "lint": "oxlint --report-unused-disable-directives",
     "lint:fix": "oxlint --report-unused-disable-directives --fix",
     "format": "oxfmt --check .",

--- a/packages/modal/src/components/magic-modal.browser.web.test.tsx
+++ b/packages/modal/src/components/magic-modal.browser.web.test.tsx
@@ -251,6 +251,26 @@ describe("browser chrome", () => {
     expect(stackEntries()).toBe(0);
   });
 
+  it("ships recursive pointer isolation for every exiting descendant", async () => {
+    await render();
+    await show({ animationOutTiming: 300 });
+
+    await act(async () => {
+      magicModal.hideAll();
+    });
+
+    const button = byTestID("modal-button");
+    const stylesheet = [...query("style")].find(({ textContent }) =>
+      textContent?.includes("magic-modal-box-none"),
+    );
+
+    expect(stackEntries()).toBe(1);
+    expect(button?.closest(".magic-modal-none")).not.toBeNull();
+    expect(stylesheet?.textContent).toContain(".magic-modal-none *");
+
+    await finishAllAnimations();
+  });
+
   it("hands the dialog role down the stack the moment the top is dismissed", async () => {
     await render();
     await show({ accessibilityLabel: "First" });

--- a/packages/modal/src/components/webModal/modal-styles.ts
+++ b/packages/modal/src/components/webModal/modal-styles.ts
@@ -84,7 +84,8 @@ export const MODAL_STYLESHEET = `.${MODAL_CLASS.portal},
 }
 
 .${MODAL_CLASS.boxNone},
-.${MODAL_CLASS.none} {
+.${MODAL_CLASS.none},
+.${MODAL_CLASS.none} * {
   pointer-events: none !important;
 }
 
@@ -92,9 +93,6 @@ export const MODAL_STYLESHEET = `.${MODAL_CLASS.portal},
   pointer-events: auto;
 }
 
-.${MODAL_CLASS.none} > * {
-  pointer-events: none;
-}
 `;
 
 /** Joins class names, skipping the ones a conditional turned off. */

--- a/packages/modal/src/index.react-native.ts
+++ b/packages/modal/src/index.react-native.ts
@@ -8,6 +8,7 @@ export {
   MagicModalHideReason,
   type HideReturn,
   type ModalChildren,
+  type ModalConfigCommon,
   type ModalHandle,
   type Direction,
 } from "./constants/types";
@@ -15,6 +16,7 @@ export type {
   ModalProps,
   NewConfigProps,
 } from "./constants/types.react-native";
+export type { MagicModalAPI } from "./utils/magic-modal-handler";
 export { useMagicModal } from "./components/magic-modal-provider";
 
 /**

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -8,10 +8,12 @@ export {
   MagicModalHideReason,
   type HideReturn,
   type ModalChildren,
+  type ModalConfigCommon,
   type ModalHandle,
   type Direction,
 } from "./constants/types";
 export type { ModalProps, NewConfigProps } from "./constants/types.browser";
+export type { MagicModalAPI } from "./utils/magic-modal-handler";
 export { useMagicModal } from "./components/magic-modal-provider";
 
 /**

--- a/packages/modal/tools/check-pack-consumer.mjs
+++ b/packages/modal/tools/check-pack-consumer.mjs
@@ -1,0 +1,121 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const packageDirectory = resolve(import.meta.dirname, "..");
+const workspaceDirectory = resolve(packageDirectory, "../..");
+const fixture = mkdtempSync(join(tmpdir(), "magic-modal-pack-consumer-"));
+const packageInstall = join(fixture, "node_modules/magic-modal");
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+/** @param {string} name */
+const linkWorkspacePackage = (name) => {
+  const source = join(workspaceDirectory, "node_modules", name);
+  const destination = join(fixture, "node_modules", name);
+  mkdirSync(dirname(destination), { recursive: true });
+  symlinkSync(
+    source,
+    destination,
+    process.platform === "win32" ? "junction" : "dir",
+  );
+};
+
+try {
+  /** @type {string} */
+  const packOutput = execFileSync(
+    pnpm,
+    ["pack", "--pack-destination", fixture],
+    {
+      cwd: packageDirectory,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const archive = packOutput
+    .trim()
+    .split("\n")
+    .find((line) => line.endsWith(".tgz"));
+
+  if (!archive)
+    throw new Error(`pnpm pack returned no archive:\n${packOutput}`);
+
+  mkdirSync(packageInstall, { recursive: true });
+  execFileSync(
+    "tar",
+    ["-xzf", archive, "--strip-components=1", "-C", packageInstall],
+    { stdio: "pipe" },
+  );
+
+  for (const dependency of [
+    "@types/react",
+    "react",
+    "react-native",
+    "react-native-gesture-handler",
+    "react-native-reanimated",
+    "react-native-screens",
+    "react-native-worklets",
+  ]) {
+    linkWorkspacePackage(dependency);
+  }
+
+  writeFileSync(
+    join(fixture, "consumer.ts"),
+    'import { magicModal } from "magic-modal";\nexport const modal = magicModal;\n',
+  );
+
+  for (const [target, customConditions] of [
+    ["web", []],
+    ["react-native", ["react-native"]],
+  ]) {
+    const outDir = join(fixture, `types-${target}`);
+    const config = join(fixture, `tsconfig.${target}.json`);
+    writeFileSync(
+      config,
+      JSON.stringify({
+        compilerOptions: {
+          customConditions,
+          declaration: true,
+          emitDeclarationOnly: true,
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          outDir,
+          skipLibCheck: true,
+          strict: true,
+          target: "ES2022",
+        },
+        files: ["consumer.ts"],
+      }),
+    );
+
+    execFileSync(
+      process.execPath,
+      [
+        join(workspaceDirectory, "node_modules/typescript/bin/tsc"),
+        "-p",
+        config,
+      ],
+      { cwd: fixture, stdio: "pipe" },
+    );
+
+    const declaration = readFileSync(join(outDir, "consumer.d.ts"), "utf8");
+    if (!declaration.includes("export declare const modal:")) {
+      throw new Error(
+        `${target} consumer emitted no public modal declaration.`,
+      );
+    }
+  }
+
+  console.log(
+    "✓ Packed declarations: web and React Native consumers emit cleanly",
+  );
+} finally {
+  rmSync(fixture, { force: true, recursive: true });
+}


### PR DESCRIPTION
## Summary

Stops an exiting web modal from catching clicks while its exit animation is still running. Also exports the API types referenced by the built declaration files.

[Watch the local Chrome proof (MP4)](https://raw.githubusercontent.com/GSTJ/magic-modal/e0ecbcb4e70a3218da6021e2f228bfd77c33ed56/evidence/pointer-through-proof.mp4)

| First click | Second click at the same point |
| --- | --- |
| ![The cursor on the confirm action before dismissal](https://raw.githubusercontent.com/GSTJ/magic-modal/e0ecbcb4e70a3218da6021e2f228bfd77c33ed56/evidence/pointer-through-proof-mid.png) | ![The modal is gone and the handler count remains one](https://raw.githubusercontent.com/GSTJ/magic-modal/e0ecbcb4e70a3218da6021e2f228bfd77c33ed56/evidence/pointer-through-proof-pass.png) |

The recording uses the production Next.js build. A red cursor dot and the status panel were injected for the recording only. The second click lands at the same coordinates during the exit animation. The confirm handler count stays at one.

## Details

- Applies `pointer-events: none !important` to an exiting modal and every descendant. A nested control can no longer override the disabled stack entry while it remains mounted for animation.
- Adds a browser regression test and a Chrome smoke check for the click-through path. Before sending the second click, the smoke check confirms that `elementFromPoint` no longer resolves to the stale action.
- Exports `MagicModalAPI` and `ModalConfigCommon` from both public entry points. The packed-package consumer now generates declarations using both the web and React Native export conditions.
- Leaves native modal input behavior unchanged.

## Testing steps

```sh
pnpm install --frozen-lockfile
pnpm build
pnpm lint
pnpm format
pnpm typecheck
pnpm test
pnpm doctor
pnpm changelog:check
pnpm release:check
pnpm registry:check
pnpm run docs
pnpm audit
node examples/next-web/tools/browser-smoke.mjs
```

The full local run passed 128 package tests and 9 docs tests. The docs build produced 53 routes and 37 HTML files. It checked 828 links. Expo Doctor passed all 19 checks. `pnpm registry:check` passed. `pnpm audit` found no known vulnerabilities.
