### PR TITLE
fix(ci): attach release preparation to source commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,9 @@ jobs:
           BEFORE=$(node -p "require('./packages/modal/package.json').version")
           git config user.name "Gabriel Taveira"
           git config user.email "gabrielstaveira@gmail.com"
+          node packages/modal/tools/attach-release-branch.mjs \
+            "$SOURCE_SHA" \
+            "release-preparation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           pnpm --filter magic-modal run release
           pnpm --dir packages/react-native-magic-modal exec node tools/sync-manifest.mjs --write
           git add packages/modal/package.json packages/modal/CHANGELOG.md packages/react-native-magic-modal/package.json

--- a/packages/modal/tools/attach-release-branch.mjs
+++ b/packages/modal/tools/attach-release-branch.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+
+const [sourceSha = "", branchName = ""] = process.argv.slice(2);
+const SHA = /^[0-9a-f]{40}$/u;
+const BRANCH = /^release-preparation-[1-9]\d*-[1-9]\d*$/u;
+
+/** @param {string[]} args */
+const git = (...args) =>
+  execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+
+/** @param {string[]} args */
+const tryGit = (...args) => {
+  try {
+    return git(...args);
+  } catch {
+    return "";
+  }
+};
+
+assert.match(sourceSha, SHA, "the release source must be a full commit SHA");
+assert.match(
+  branchName,
+  BRANCH,
+  "the local release branch has an invalid name",
+);
+assert.equal(
+  git("rev-parse", "HEAD"),
+  sourceSha,
+  "HEAD moved after classification",
+);
+assert.equal(
+  tryGit("symbolic-ref", "--quiet", "HEAD"),
+  "",
+  "the release checkout must start detached",
+);
+assert.equal(
+  git("rev-parse", "origin/main"),
+  sourceSha,
+  "origin/main does not match the classified source",
+);
+assert.equal(
+  tryGit("show-ref", "--verify", `refs/heads/${branchName}`),
+  "",
+  `${branchName} already exists`,
+);
+
+git("switch", "--create", branchName, sourceSha);
+git("branch", "--set-upstream-to=origin/main", branchName);
+
+assert.equal(
+  git("rev-parse", "HEAD"),
+  sourceSha,
+  "the local branch moved HEAD",
+);
+assert.equal(
+  git("symbolic-ref", "HEAD"),
+  `refs/heads/${branchName}`,
+  "HEAD is still detached",
+);
+assert.equal(
+  git("rev-parse", "@{upstream}"),
+  sourceSha,
+  "the local branch does not track the classified main commit",
+);
+
+console.log(`release preparation attached to ${branchName} at ${sourceSha}`);

--- a/packages/modal/tools/burned-version-check.mjs
+++ b/packages/modal/tools/burned-version-check.mjs
@@ -35,6 +35,7 @@ import { BURNED_VERSIONS } from "./skip-burned-versions.mjs";
 
 const here = import.meta.dirname;
 const realConfig = join(here, "..", ".release-it.js");
+const attachReleaseBranch = join(here, "attach-release-branch.mjs");
 
 // Resolved rather than assumed to sit at ../node_modules/.bin: pnpm hoists,
 // and in a workspace the binary can land in the root store instead of the
@@ -106,10 +107,35 @@ const inThrowawayRepo = async (commitMessage, run) => {
  *
  * @param {string} commitMessage
  * @param {string} configPath
+ * @param {{ detached?: boolean }} [options]
  * @returns {Promise<string>}
  */
-const releaseVersionFor = (commitMessage, configPath) =>
+const releaseVersionFor = (
+  commitMessage,
+  configPath,
+  { detached = false } = {},
+) =>
   inThrowawayRepo(commitMessage, (repo) => {
+    if (detached) {
+      const sourceSha = execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: repo,
+        encoding: "utf8",
+      }).trim();
+      execFileSync("git", ["push", "--quiet", "origin", "main"], {
+        cwd: repo,
+        stdio: "pipe",
+      });
+      execFileSync("git", ["switch", "--detach", sourceSha], {
+        cwd: repo,
+        stdio: "pipe",
+      });
+      execFileSync(
+        process.execPath,
+        [attachReleaseBranch, sourceSha, "release-preparation-1-1"],
+        { cwd: repo, stdio: "pipe" },
+      );
+    }
+
     const output = execFileSync(
       process.execPath,
       [releaseItBin, "--release-version", "--ci", "--config", configPath],
@@ -149,6 +175,14 @@ const guardedPatch = await releaseVersionFor(ORDINARY, realConfig);
 expect(
   `a fix over 10.1.1 still releases 10.1.2 (got ${guardedPatch})`,
   guardedPatch === "10.1.2",
+);
+
+const detachedPatch = await releaseVersionFor(ORDINARY, realConfig, {
+  detached: true,
+});
+expect(
+  `a detached release checkout attaches safely and releases 10.1.2 (got ${detachedPatch})`,
+  detachedPatch === "10.1.2",
 );
 
 // 3. Negative control: the raw plugin with the same options computes the
@@ -201,5 +235,5 @@ if (failures.length > 0) {
 }
 
 console.log(
-  `burned version check passed (breaking over 10.1.1: guarded=${guardedMajor}, raw plugin=${unguardedMajor}; fix over 10.1.1: ${guardedPatch})`,
+  `burned version check passed (breaking over 10.1.1: guarded=${guardedMajor}, raw plugin=${unguardedMajor}; fix over 10.1.1: attached=${detachedPatch}, branch=${guardedPatch})`,
 );


### PR DESCRIPTION
## Summary

The release workflow checks out the exact source commit in detached mode, but release-it requires a symbolic branch before it prepares a commit. That stopped [the first 10.2.1 run](https://github.com/GSTJ/magic-modal/actions/runs/33414975251) before it created a version patch.

This change creates a run-scoped local branch only after confirming that `HEAD` and `origin/main` both match the classified source SHA. It then verifies the branch and its upstream before release-it runs.

![Detached release checkout proof](https://raw.githubusercontent.com/GSTJ/magic-modal/75591cf64561434cbe101634ecd8b6172714e981/evidence/release-detached-head-proof.png)

## Testing

```sh
actionlint .github/workflows/release.yml
pnpm --filter magic-modal run release:check
pnpm --filter magic-modal run lint
pnpm --filter magic-modal run format
git diff --check
```

The release check now recreates a detached checkout against the real release-it config. It attaches the exact commit, validates its upstream, and computes the expected patch version without creating a package, tag, release, or remote branch.

The complete workspace build, lint, format, typecheck, tests, Expo Doctor, changelog, release, registry, docs, and audit gates also passed. That run covered 128 package tests, 9 docs tests, all 19 Expo checks, 53 docs routes, 37 HTML files, and 828 links.
