### PR TITLE
fix(ci): wait for npm provenance propagation

### DIFF
--- a/packages/modal/tools/release-artifacts.mjs
+++ b/packages/modal/tools/release-artifacts.mjs
@@ -13,6 +13,12 @@ const githubActionsBuildType =
   "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1";
 const sigstoreBundleType = "application/vnd.dev.sigstore.bundle.v0.3+json";
 const inTotoPayloadType = "application/vnd.in-toto+json";
+const registryProvenancePollIntervalMs = 3_000;
+const registryProvenancePollTimeoutMs = 5 * 60_000;
+const registryProvenancePollAttempts =
+  Math.ceil(
+    registryProvenancePollTimeoutMs / registryProvenancePollIntervalMs,
+  ) + 1;
 
 /** @typedef {{ dependencies?: Record<string, string>; name: string; version: string }} PackageManifest */
 /** @typedef {{ file: string; integrity: string; name: string; sha256: string; sha512: string; version: string }} ReleaseArtifact */
@@ -602,12 +608,12 @@ const verifyRegistryAttempt = async (metadata, attempt) => {
     console.log(`registry bytes and provenance match ${metadata.version}`);
     return;
   }
-  if (attempt >= 20) {
+  if (attempt >= registryProvenancePollAttempts) {
     throw new Error(
-      `npm did not expose both provenance attestations within 60 seconds`,
+      `npm did not expose both provenance attestations within ${registryProvenancePollTimeoutMs / 1_000} seconds`,
     );
   }
-  await delay(3_000);
+  await delay(registryProvenancePollIntervalMs);
   return verifyRegistryAttempt(metadata, attempt + 1);
 };
 


### PR DESCRIPTION
## Summary

The release verifier now gives npm up to five minutes to expose provenance after publishing. Registry propagation can finish without leaving an otherwise complete release half-finalized.

## Details

- Keeps the three-second poll interval and raises the bounded window from one minute to five.
- Derives the retry limit and failure message from the same timeout.
- The recovery path still rejects different tarball bytes. Packages whose exact bytes and provenance already exist are verified and skipped.

![npm provenance recovery](https://raw.githubusercontent.com/GSTJ/magic-modal/b1178a7186bb770097aa88bd278658dbbbef2e47/evidence/release-provenance-polling-proof.png)

## Testing steps

1. Run:

```sh
pnpm release:check
```

2. Confirm the output ends with `release tree 10.2.1 is internally consistent`.
3. Open the [recovery run](https://github.com/GSTJ/magic-modal/actions/runs/33417201078) and confirm both existing packages are skipped, the signature checks pass, and the tag and release are finalized.