### PR TITLE
fix(deps): patch URI parser vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,13 @@ overrides:
   lodash: ^4.18.0
   tmp: ^0.2.6
   brace-expansion: ^5.0.9
-  fast-uri: ^3.1.5
+  decode-uri-component: ^0.5.0
+  fast-uri: ^3.1.6
   hono: ^4.12.34
   js-yaml@3.15.0: 5.3.0
   js-yaml@4.3.0: 4.3.1
   nanoid@3.3.16: 3.3.18
+  qs: ^6.16.0
   uuid: ^14.0.0
   postcss: ^8.5.23
   sharp: ^0.35.3
@@ -5182,9 +5184,9 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  decode-uri-component@0.2.2:
-    resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
-    engines: {node: '>=0.10'}
+  decode-uri-component@0.5.0:
+    resolution: {integrity: sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==}
+    engines: {node: '>=14.16'}
 
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
@@ -5780,8 +5782,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -8119,8 +8121,8 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   query-string@7.1.3:
@@ -13554,14 +13556,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13804,7 +13806,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -14403,7 +14405,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decode-uri-component@0.2.2: {}
+  decode-uri-component@0.5.0: {}
 
   dedent@0.7.0: {}
 
@@ -15077,7 +15079,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@8.1.1)
       send: 1.2.1(supports-color@8.1.1)
@@ -15112,7 +15114,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -18037,14 +18039,14 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
 
   query-string@7.1.3:
     dependencies:
-      decode-uri-component: 0.2.2
+      decode-uri-component: 0.5.0
       filter-obj: 1.1.0
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,11 +17,13 @@ overrides:
   "lodash": "^4.18.0"
   "tmp": "^0.2.6"
   "brace-expansion": "^5.0.9"
-  "fast-uri": "^3.1.5"
+  "decode-uri-component": "^0.5.0"
+  "fast-uri": "^3.1.6"
   "hono": "^4.12.34"
   "js-yaml@3.15.0": "5.3.0"
   "js-yaml@4.3.0": "4.3.1"
   "nanoid@3.3.16": "3.3.18"
+  "qs": "^6.16.0"
   "uuid": "^14.0.0"
   # Both of these reach us through next in apps/docs, and bumping next fixes
   # neither. It pins `"postcss": "8.4.31"` exactly and takes `sharp: "^0.34.5"`
@@ -289,11 +291,11 @@ minimumReleaseAgeExclude:
   - "yuku-ast@0.8.2"
   - "zbsearch@3.3.4"
   - "brace-expansion@5.0.9" # GHSA-rgw5-rvv9-x895
-  - "fast-uri@3.1.5" # GHSA-7p8r-x3mc-p8w7
   - "hono@4.12.34" # GHSA-8j4g-w8fx-2239
   - "js-yaml@3.15.1" # GHSA-5p4m-2wfm-xmqj
   - "js-yaml@4.3.1" # GHSA-5p4m-2wfm-xmqj
   - "nanoid@3.3.18" # GHSA-2v37-7h3g-55p8
+  - "qs@6.16.0" # GHSA-4mjr-xmp4-gh2g, GHSA-x5fp-wj9c-mxmx
   # Our own plugin, published from this account 2026-07-27 — same first-party
   # exemption the sibling repos carry. Version-pinned like the rest.
   - "eslint-plugin-safe-jsx@1.3.0"


### PR DESCRIPTION
## Summary

Clean installs now resolve the affected transitive packages to fixed releases.

## Details

- Resolves `fast-uri` to 3.1.6, `decode-uri-component` to 0.5.0, and `qs` to 6.16.0 across the workspace.
- The affected paths belong to repository tooling, docs, and examples. The published packages still contain only their built output and peer declarations.
- Removes the old `fast-uri` quarantine exception and allows the `qs` security release through the 14-day hold.

## Testing steps

1. Open a terminal in the project and install the dependencies:

   ```sh
   nvm use
   pnpm install --frozen-lockfile
   ```

2. Run the dependency audit and full test suite:

   ```sh
   pnpm audit
   pnpm run test
   ```

   The audit should print `No known vulnerabilities found`, and the test command should exit successfully.

3. Run the browser check:

   ```sh
   pnpm --filter @magic-modal/next-web run smoke:browser
   ```

   The command should confirm the dialog, focus, Escape, backdrop, swipe, and exit checks.
